### PR TITLE
Prettify JSON in .apib output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# Elixir LS
+.elixir_ls
+
 # End of https://www.gitignore.io/api/macos

--- a/lib/blue_bird/writer/blueprint.ex
+++ b/lib/blue_bird/writer/blueprint.ex
@@ -158,7 +158,10 @@ defmodule BlueBird.Writer.Blueprint do
     [
       "+ Response #{response.status}#{get_content_type(response.headers)}\n",
       response.headers |> filter_headers() |> print_headers() |> indent(4),
-      response.body |> print_body() |> indent(4)
+      response.body
+      |> Jason.Formatter.pretty_print()
+      |> print_body()
+      |> indent(4)
     ]
     |> Enum.reject(&(&1 == ""))
     |> Enum.join("\n")
@@ -374,7 +377,9 @@ defmodule BlueBird.Writer.Blueprint do
 
   @spec print_body_params(map) :: String.t()
   defp print_body_params(body) when body == %{}, do: ""
-  defp print_body_params(body), do: body |> Jason.encode!() |> print_body()
+
+  defp print_body_params(body),
+    do: body |> Jason.encode!(pretty: true) |> print_body()
 
   @spec indent(String.t(), integer) :: String.t()
   defp indent(str, count) do


### PR DESCRIPTION
Originally, JSON outputs are written as one-line in generated .apib file by blue_bird. This PR ensures that request and response bodies are prettified in the generated `.apib` so that the current aglio in this commit https://github.com/Gasol/aglio/commit/46d13945675711f55dc72b03b361c516785ef298 will display the JSON request and response bodies properly.

Sample before:
```
+ Body

            {"email": "candidate507@example.com","password": "supersecret"}
```

Sample after:
```
+ Body

            {
              "email": "candidate507@example.com",
              "password": "supersecret"
            }
```